### PR TITLE
perf: is_market_open() 날짜 단위 캐싱으로 schedule() 불필요한 반복 호출 제거

### DIFF
--- a/main_ver15.py
+++ b/main_ver15.py
@@ -53,12 +53,17 @@ def get_target_hour():
 
 # 전역 변수로 NYSE 캘린더 객체를 한 번만 생성하여 재사용합니다. (리소스 최적화)
 NYSE_CALENDAR = mcal.get_calendar('NYSE')
+# 날짜 단위 캐시: 하루에 schedule() 를 1회만 실행하기 위한 저장소
+_market_open_cache = {"date": None, "result": None}
 
 def is_market_open():
     est = pytz.timezone('US/Eastern')
     today = datetime.datetime.now(est).date()
-    # 전역 캘린더 객체 사용 및 스케줄 조회 최적화
-    return not NYSE_CALENDAR.schedule(start_date=today, end_date=today).empty
+    # 오늘 날짜로 아직 조회한 적 없을 때만 schedule() 실행, 이후 호출은 캐시 반환
+    if _market_open_cache["date"] != today:
+        _market_open_cache["date"] = today
+        _market_open_cache["result"] = not NYSE_CALENDAR.schedule(start_date=today, end_date=today).empty
+    return _market_open_cache["result"]
 
 def get_budget_allocation(cash, tickers, cfg):
     sorted_tickers = sorted(tickers, key=lambda x: 0 if x == "SOXL" else (1 if x == "TQQQ" else 2))


### PR DESCRIPTION
  ## 문제
  scheduled_premarket_monitor가 60초마다 is_market_open()을 호출하며,
  매 호출마다 NYSE_CALENDAR.schedule()이 실행되어 pandas DataFrame을 생성했음.
  "오늘이 거래일인가?"라는 답이 하루 종일 바뀌지 않음에도 최대 1,440회/일 동일한 연산을 반복.

  ## 수정
  - _market_open_cache 전역 딕셔너리 추가 (date, result 키)
  - is_market_open() 내부에서 오늘 날짜와 캐시 날짜가 다를 때만 schedule() 실행
  - 날짜가 같으면 저장된 결과를 즉시 반환 (캐시 히트)
  - 자정이 지나 날짜가 바뀌면 자동으로 캐시 무효화 후 재계산

  ## 결과
  - schedule() 호출: 최대 1,440회/일 → 1회/일
  - 결과 정확성 및 자정 경계 처리 동일하게 유지